### PR TITLE
Link the legal pages the way they are served

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -534,8 +534,8 @@
       <a href="https://hub.docker.com/r/artsamsonov/transcriptor-mcp">Docker Hub</a>
       <a href="https://registry.modelcontextprotocol.io/v0/servers?search=transcriptor">MCP Registry</a>
       <a href="/llms.txt">llms.txt</a>
-      <a href="/terms">Terms of Service</a>
-      <a href="/privacy">Privacy Policy</a>
+      <a href="/terms/">Terms of Service</a>
+      <a href="/privacy/">Privacy Policy</a>
       <a href="mailto:contact@transcriptor-mcp.org">Contact</a>
     </div>
     <p>© 2026 <a href="https://www.linkedin.com/in/artem-samsonov-284a66105/">Artem Samsonov</a></p>

--- a/web/template.html
+++ b/web/template.html
@@ -133,8 +133,8 @@
   </main>
   <footer class="site">
     <a href="/">Home</a>
-    <a href="/terms">Terms of Service</a>
-    <a href="/privacy">Privacy Policy</a>
+    <a href="/terms/">Terms of Service</a>
+    <a href="/privacy/">Privacy Policy</a>
     <a href="mailto:legal@transcriptor-mcp.org">legal@transcriptor-mcp.org</a>
   </footer>
 </div>


### PR DESCRIPTION
## What

The footer links to `/terms` and `/privacy`; this changes them to `/terms/` and `/privacy/`, in `web/index.html` and `web/template.html`.

## Why

Found while releasing the site to Cloudflare Pages. The build writes each legal page to its own directory (`dist-site/terms/index.html`), so Pages answers `/terms` with a 308 to `/terms/`:

```
$ curl -sI https://transcriptor-mcp.pages.dev/terms
HTTP/2 308
location: /terms/
```

The canonical tags and `sitemap.xml` already used the trailing slash — only the internal links did not, so every reader who opened the Terms or the Privacy Policy from the footer went through a redirect first, on every page of the site.

## Review notes

- Two lines in each of two files; no build-script or content change.
- The generated `dist-site/` confirms the fix: `grep -o 'href="/[a-z-]*/\?"' dist-site/index.html` now yields only `href="/privacy/"` and `href="/terms/"`.
- Already deployed — the Pages production deployment serving `transcriptor-mcp.pages.dev` was built from this commit, and the live `index.html` matches `dist-site/index.html` by SHA-256.
- The pre-commit hook ran lint, format check, type-check, 246 tests and the full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)