### PR TITLE
Fill the widget columns in the build, not with multi-column CSS

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,49 @@
+# Publish transcriptor-mcp.org to Cloudflare Pages whenever the sources the
+# site is built from land on main. The Pages project is `transcriptor-mcp`
+# and its production branch is `main`, so this deployment is the live one.
+#
+# Requires two repository secrets:
+#   CLOUDFLARE_API_TOKEN   — a token with the "Cloudflare Pages: Edit" permission
+#   CLOUDFLARE_ACCOUNT_ID  — the account the Pages project belongs to
+name: Deploy site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - 'legal/**'
+      - 'assets/widget-*.webp'
+      - 'package.json'
+      - '.github/workflows/deploy-site.yml'
+  workflow_dispatch:
+
+# One deployment at a time, and never an older commit overwriting a newer one.
+concurrency:
+  group: deploy-site
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build the site
+        run: npm run build:site
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist-site --project-name=transcriptor-mcp --branch=main

--- a/web/build.mjs
+++ b/web/build.mjs
@@ -244,21 +244,40 @@ const WIDGET_TILES = [
   { id: 'video-frame', caption: '<code>get_video_frame</code> · a frame with step controls' },
 ];
 
+// Half the tiles per column, in reading order. The page used to hand the
+// packing to CSS multi-column, which fragments the flow itself — and a
+// fragmented .snapshot-frame paints as a blank box in WebKit, because the
+// clip its overflow and radius create is resolved against the column the
+// tile started in. Filling the columns here keeps each tile whole.
+function splitIntoColumns(items, columns = 2) {
+  const perColumn = Math.ceil(items.length / columns);
+  return Array.from({ length: columns }, (_, i) =>
+    items.slice(i * perColumn, (i + 1) * perColumn)
+  ).filter((column) => column.length > 0);
+}
+
 async function renderWidgetTiles() {
-  const tiles = [];
+  const rendered = new Map();
   for (const tile of WIDGET_TILES) {
     const html = await readFile(
       path.join(root, 'web/widgets-demo/snapshots', `${tile.id}.html`),
       'utf8'
     );
-    tiles.push(
+    rendered.set(
+      tile.id,
       `<figure class="tile">\n` +
-        `        <div class="snapshot-frame"${tile.scrolls ? ' data-scrolls' : ''}>` +
+        `          <div class="snapshot-frame"${tile.scrolls ? ' data-scrolls' : ''}>` +
         `<div class="snapshot" aria-hidden="true">${html.trim()}</div></div>\n` +
-        `        <figcaption>${tile.caption}</figcaption>\n      </figure>`
+        `          <figcaption>${tile.caption}</figcaption>\n        </figure>`
     );
   }
-  return `<div class="widget-tiles">\n      ${tiles.join('\n      ')}\n    </div>`;
+  const columns = splitIntoColumns(WIDGET_TILES).map(
+    (column) =>
+      `<div class="tile-col">\n        ` +
+      column.map((tile) => rendered.get(tile.id)).join('\n        ') +
+      `\n      </div>`
+  );
+  return `<div class="widget-tiles">\n      ${columns.join('\n      ')}\n    </div>`;
 }
 
 let landing = await readFile(path.join(root, 'web/index.html'), 'utf8');

--- a/web/index.html
+++ b/web/index.html
@@ -329,10 +329,18 @@
   td { border-bottom: 1px solid var(--line-soft); }
   td code { font-size: 13px; color: var(--accent); }
 
-  /* Widget tiles: static snapshots of the real widget DOM. Two CSS
-     columns pack the different natural heights without holes. */
-  .widget-tiles { columns: 2; column-gap: 20px; margin-top: 18px; }
-  .tile { break-inside: avoid; margin: 0 0 20px; }
+  /* Widget tiles: static snapshots of the real widget DOM. Two columns
+     pack the different natural heights without holes; the build fills
+     them, so no tile is ever fragmented. CSS multi-column did the same
+     packing in one rule, but WebKit fails to paint a fragment that owns
+     a clip — .snapshot-frame clips with overflow plus a radius — and the
+     tile the break lands on came out blank in Safari. */
+  .widget-tiles {
+    display: grid; grid-template-columns: 1fr 1fr;
+    gap: 20px; align-items: start; margin-top: 18px;
+  }
+  .tile-col { display: flex; flex-direction: column; gap: 20px; min-width: 0; }
+  .tile { margin: 0; }
   .snapshot-frame {
     position: relative;
     border: 1px solid var(--line); border-radius: 12px;
@@ -360,7 +368,9 @@
   figcaption { font-size: 13px; color: var(--muted); margin-top: 7px; text-align: center; }
   figcaption code { font-size: 12px; color: var(--accent); }
   @media (max-width: 720px) {
-    .widget-tiles { columns: 1; }
+    /* One column: the two build-filled columns stack, and because the
+       build fills them in reading order the tiles keep that order. */
+    .widget-tiles { grid-template-columns: 1fr; }
   }
 
   footer { margin-top: 56px; border-top: 1px solid var(--line); padding: 26px 0 40px; font-size: 14px; color: var(--muted); }


### PR DESCRIPTION
## The bug

The `get_transcript` tile rendered as a blank box in Safari. Not misplaced — unpainted: the frame, its border, its white background and everything inside it were absent, while the layout still reserved the full 426×705.

## Why

The tiles were packed with `columns: 2`, which fragments the flow, and `.snapshot-frame` owns a clip (`overflow: hidden` plus a `border-radius`). WebKit resolves that clip against the column the tile *started* in, so once the break moved the tile into the second column its content fell outside the clip and vanished.

`-webkit-column-break-inside: avoid` is the usual incantation here and it does **not** apply: the break itself was already correct — WebKit reported `break-inside: avoid` as computed and never split a tile. Only painting was wrong.

## The fix

`renderWidgetTiles` now splits the tiles into two `.tile-col` flex columns in reading order, and the section is a plain grid. Nothing fragments, so the clip has nothing to be resolved against wrongly.

- Desktop arrangement is unchanged — multi-column had also settled on two tiles per column, in the same order.
- The phone layout still collapses to one column, and because the build fills the columns in reading order the tiles keep that order.

## Verification

Run against real WebKit (the Playwright `webkit-2215` build), not inferred:

| | before | after |
|---|---|---|
| `get_transcript` frame | painted nothing | `426x678`, content `424x676` |
| other three tiles | fine | fine |

Checked at 1280, 900 and 375px in WebKit and Chromium: all four tiles report real frame and content boxes, no horizontal document overflow, console clean. Also confirmed the hero animation still completes in WebKit, and that the one element extending past the viewport at 375px is the endpoint URL inside `.endpoint-scroll` (`overflow-x: auto`, 357 vs 232) — scrolling in its own container, as designed, and identical in Chromium.

Already live: the fix is deployed to the `transcriptor-mcp` Pages project, and https://transcriptor-mcp.org verifies clean in WebKit.

## Also in this PR

`.github/workflows/deploy-site.yml` — builds the site and deploys it to Cloudflare Pages on every push to `main` touching `web/`, `legal/`, the widget assets or `package.json`, plus a manual trigger. `concurrency` with `cancel-in-progress` keeps an older commit from overwriting a newer one. It reads `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`, both already set on the repository.

Every input the build reads is tracked in git, so it builds from a clean clone. The workflow's own `workflow_dispatch` only becomes available once this lands on the default branch.

Note: `web/index.html` is also touched by #8 (footer links to the legal pages), in a different part of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)