### PR TITLE
Point the README at the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 **Connect one server. Then ask Claude, ChatGPT or etc about a video:** the transcript, the chapters, the metadata, or a single frame. It works with 11 platforms, not only YouTube.
 
+[![Website](https://img.shields.io/badge/Website-transcriptor--mcp.org-C15F3C)](https://transcriptor-mcp.org)
 [![MCP Registry](https://img.shields.io/badge/MCP%20Registry-transcriptor--mcp-6E56CF)](https://registry.modelcontextprotocol.io/v0/servers?search=transcriptor)
 [![Docker](https://img.shields.io/badge/Docker-artsamsonov/transcriptor--mcp-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/artsamsonov/transcriptor-mcp)
 [![MCP Apps](https://img.shields.io/badge/MCP%20Apps-4%20interactive%20widgets-8A63D2)](#-widgets)


### PR DESCRIPTION
## What

Adds a **Website** badge, first in the badge row of the README header:

```
[![Website](https://img.shields.io/badge/Website-transcriptor--mcp.org-C15F3C)](https://transcriptor-mcp.org)
```

## Why

The site went live at transcriptor-mcp.org and the README did not mention it anywhere — `grep transcriptor-mcp.org README.md` came back empty.

It leads the row rather than trailing it because the site is now the front door: the one-click install links, a ready snippet for each of the twelve supported clients, and the widget snapshots all live there, and several of those are more complete on the site than in this file.

## Review notes

- One line, docs only.
- The colour is the site's own accent, `#C15F3C`, so the badge matches the brand mark rather than picking an arbitrary shields default.
- Verified: shields.io serves the badge (200) and renders the doubled dash back as `transcriptor-mcp.org`; the link target answers 200.
- `README.md` is outside the path filter of `.github/workflows/deploy-site.yml`, so merging this does not trigger a site redeploy.
- The pre-commit hook ran lint, format check, type-check, 246 tests and the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)