### PR TITLE
Move the endpoint into the client panels that need it

### DIFF
--- a/web/build.mjs
+++ b/web/build.mjs
@@ -65,11 +65,34 @@ const pretty = (config) => JSON.stringify(config, null, 2);
 
 const installLabels = { cursor: 'Add to Cursor', vscode: 'Add to VS Code', lmstudio: 'Add to LM Studio' };
 
+const copyIcon =
+  '<svg class="i-copy" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+  '<rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+const doneIcon =
+  '<svg class="i-done" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+  '<path d="M20 6 9 17l-5-5"/></svg>';
+
+// A code block with the copy control over its trailing edge. The text lives
+// in the DOM and the button points at it, so multi-line configs need no
+// attribute escaping.
+function renderCopyBlock(id, text, label) {
+  return (
+    `<div class="pre-wrap">` +
+    `<pre id="${id}">${esc(text)}</pre>` +
+    `<button type="button" class="copy-btn" data-copy-target="#${id}"` +
+    ` aria-label="${label}" title="${label}">${copyIcon}${doneIcon}</button>` +
+    `</div>`
+  );
+}
+
 function renderPanelBody(client) {
   const parts = [];
   if (client.heading) parts.push(`<h3>${client.heading}</h3>`);
   if (client.kind === 'steps') {
     parts.push(`<ol class="steps">\n${client.steps.map((s) => `          <li>${s}</li>`).join('\n')}\n        </ol>`);
+    // These clients take the endpoint through their own UI, so the URL is the
+    // thing to copy here — the same block the other panels use for a config.
+    parts.push(renderCopyBlock(`url-${client.id}`, SERVER_URL, 'Copy endpoint'));
   }
   if (client.install) {
     parts.push(
@@ -90,19 +113,7 @@ function renderPanelBody(client) {
           ? client.text
           : pretty(client.config);
     const label = client.kind === 'command' ? 'Copy command' : 'Copy config';
-    const copyIcon =
-      '<svg class="i-copy" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
-      '<rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
-    const doneIcon =
-      '<svg class="i-done" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
-      '<path d="M20 6 9 17l-5-5"/></svg>';
-    parts.push(
-      `<div class="pre-wrap">` +
-        `<pre id="cfg-${client.id}">${esc(text)}</pre>` +
-        `<button type="button" class="copy-btn" data-icon data-copy-target="#cfg-${client.id}"` +
-        ` aria-label="${label}" title="${label}">${copyIcon}${doneIcon}</button>` +
-        `</div>`
-    );
+    parts.push(renderCopyBlock(`cfg-${client.id}`, text, label));
   }
   if (client.after) parts.push(`<p class="cfg-after">${client.after}</p>`);
   parts.push(`<div class="docs-row"><a class="docs-link" href="${client.docs}">${client.docsLabel}</a></div>`);

--- a/web/index.html
+++ b/web/index.html
@@ -232,21 +232,7 @@
   h2 { font-size: 28px; margin: 0; }
   .lead { color: var(--muted); margin: 6px 0 0; }
   .note { font-size: 14px; color: var(--muted); line-height: 1.5; }
-  .endpoint-note { margin: 10px 0 0; }
-
-  .endpoint {
-    display: flex; align-items: center; gap: 10px;
-    background: var(--dark); color: var(--dark-ink);
-    border-radius: 10px; padding: 12px 14px; margin: 18px 0 6px;
-  }
-  .endpoint-scroll { flex: 1; overflow-x: auto; }
-  .endpoint code { font-size: 14.5px; white-space: nowrap; }
-  .endpoint button {
-    flex-shrink: 0; background: transparent; color: var(--dark-ink);
-    border: 1px solid rgba(243, 239, 230, 0.35);
-    border-radius: 7px; padding: 5px 12px; font-size: 13px; cursor: pointer; font-family: inherit;
-  }
-  .endpoint button:hover { border-color: var(--accent); }
+  .connect-note { margin: 14px 0 0; }
 
   /* Per-client switcher: a framed card with a chip bar on top and one
      panel below; the one-click install lives inside the panel. */
@@ -317,6 +303,8 @@
   .steps { padding-left: 18px; margin: 4px 0 0; font-size: 14px; color: var(--muted); line-height: 1.6; }
   .steps li { margin: 4px 0; }
   .steps b { color: var(--ink); font-weight: 600; }
+  /* The endpoint block follows the steps that tell the reader to paste it. */
+  .steps + .pre-wrap { margin-top: 12px; }
 
   table { width: 100%; border-collapse: collapse; margin-top: 16px; font-size: 15px; }
   th, td { text-align: left; padding: 9px 12px; }
@@ -497,13 +485,9 @@
 
   <section id="connect">
     <div class="cue-head"><span class="tc">00:30</span><h2>Connect in 30 seconds</h2></div>
-    <div class="endpoint">
-      <div class="endpoint-scroll"><code id="endpoint-url">https://gateway.mcpal.io/mcp/transcriptor</code></div>
-      <button type="button" aria-live="polite" data-copy="https://gateway.mcpal.io/mcp/transcriptor">Copy</button>
-    </div>
-    <p class="note endpoint-note">Paste this into an MCP client. The first connection opens a login page; sign in once and the client keeps the session.</p>
     <!-- The build: marker below is replaced by web/build.mjs from web/clients.mjs; preview via npm run dev:site. -->
     <!-- build:clients -->
+    <p class="note connect-note">The first connection opens a login page; sign in once and the client keeps the session.</p>
   </section>
 
   <section id="ask">
@@ -582,32 +566,25 @@
     onScroll();
   }
 
-  // Copy buttons carry either the text itself (data-copy) or a selector for
-  // the element holding it (data-copy-target) — multi-line configs live in
-  // the DOM rather than in an attribute.
-  for (const btn of document.querySelectorAll('[data-copy], [data-copy-target]')) {
-    // Icon buttons swap a glyph and keep their markup; the labelled ones
-    // swap their text. Writing textContent on an icon button would delete
-    // the SVG inside it.
-    const icon = Object.hasOwn(btn.dataset, 'icon');
-    const label = icon ? btn.getAttribute('aria-label') : btn.textContent;
-    const source = btn.dataset.copyTarget ? document.querySelector(btn.dataset.copyTarget) : null;
+  // Copy buttons point at the element holding the text (data-copy-target):
+  // the text lives in the DOM, not in an attribute, so multi-line configs
+  // need no escaping. Every one of them is an icon button: feedback swaps
+  // the glyph and the label; the markup inside stays put.
+  for (const btn of document.querySelectorAll('[data-copy-target]')) {
+    const label = btn.getAttribute('aria-label');
+    const source = document.querySelector(btn.dataset.copyTarget);
     const say = (text, done) => {
-      if (icon) {
-        btn.classList.toggle('copied', done);
-        btn.setAttribute('aria-label', text);
-        btn.title = text;
-      } else {
-        btn.textContent = text;
-      }
+      btn.classList.toggle('copied', done);
+      btn.setAttribute('aria-label', text);
+      btn.title = text;
     };
     btn.addEventListener('click', async () => {
       try {
-        await navigator.clipboard.writeText(btn.dataset.copy ?? source.textContent);
+        await navigator.clipboard.writeText(source.textContent);
         say('Copied', true);
       } catch {
         const range = document.createRange();
-        range.selectNodeContents(source ?? document.getElementById('endpoint-url'));
+        range.selectNodeContents(source);
         const selection = getSelection();
         selection.removeAllRanges();
         selection.addRange(range);


### PR DESCRIPTION
## What

The Connect section opened with the endpoint URL in a box of its own, and then most client panels repeated it: the Claude Code and Gemini commands, every JSON config and the Codex TOML all carry the URL inside the code block. The box earned its place only for **Claude** and **ChatGPT**, whose panels told the reader to paste "the endpoint" without showing it.

- The standalone box is removed, with its CSS.
- The two steps panels now end with the URL as a copy block — the same block the other panels use for a config, with a **Copy endpoint** control — placed 12px under the step that says to paste it.
- The first-connection note loses its opening sentence ("Paste this into an MCP client", which pointed at the box) and moves **below** the switcher: it applies after the reader has followed whichever panel they picked.

## Follow-on cleanup in the same change

The labelled endpoint button was the only copy control on the page that was not an icon, so with it gone the handler's text-swapping branch and the `data-copy` attribute form are dead code. The handler now reads `data-copy-target` only, the build no longer emits the `data-icon` marker, and one `renderCopyBlock` helper renders both the config and the endpoint variants in `web/build.mjs`.

## Verification

WebKit and Chromium, 1280 and 375px, against the built `dist-site`:

| check | result |
|---|---|
| `#endpoint-url`, `.endpoint`, `[data-copy]`, `[data-icon]` left in the DOM | 0 |
| `url-claude` / `url-chatgpt` blocks | present, inside their panel, 12px below the steps |
| URL at 375px | scrolls inside its block (368px content in a 289px box), page has no horizontal overflow |
| copy buttons after a click | 2 SVGs kept, label `Copy endpoint` → `Copied` (Chromium), fallback selection path exercised in headless WebKit |
| note position | after the switcher |
| page errors | none |

`llms.txt` is unchanged: it keeps its `Endpoint:` line, which is the right place for a plain-text reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)