### PR TITLE
Repoint the Cursor and LM Studio install badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ https://transcriptor.gateway.mcpal.io/mcp
 
 ### 🖱️ One click
 
-[![Add to Cursor](https://img.shields.io/badge/Add%20to-Cursor-000000?style=for-the-badge&logo=cursor&logoColor=white)](https://cursor.com/install-mcp?name=transcriptor&config=eyJ1cmwiOiJodHRwczovL2dhdGV3YXkubWNwYWwuaW8vbWNwL3RyYW5zY3JpcHRvciJ9)
+[![Add to Cursor](https://img.shields.io/badge/Add%20to-Cursor-000000?style=for-the-badge&logo=cursor&logoColor=white)](https://cursor.com/install-mcp?name=transcriptor&config=eyJ1cmwiOiJodHRwczovL3RyYW5zY3JpcHRvci5nYXRld2F5Lm1jcGFsLmlvL21jcCJ9)
 [![Install in VS Code](https://img.shields.io/badge/Install%20in-VS%20Code-0098FF?style=for-the-badge&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=transcriptor&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Ftranscriptor.gateway.mcpal.io%2Fmcp%22%7D)
-[![Add to LM Studio](https://img.shields.io/badge/Add%20to-LM%20Studio-4B5563?style=for-the-badge)](https://lmstudio.ai/install-mcp?name=transcriptor&config=eyJ1cmwiOiJodHRwczovL2dhdGV3YXkubWNwYWwuaW8vbWNwL3RyYW5zY3JpcHRvciJ9)
+[![Add to LM Studio](https://img.shields.io/badge/Add%20to-LM%20Studio-4B5563?style=for-the-badge)](https://lmstudio.ai/install-mcp?name=transcriptor&config=eyJ1cmwiOiJodHRwczovL3RyYW5zY3JpcHRvci5nYXRld2F5Lm1jcGFsLmlvL21jcCJ9)
 
 ### ⌨️ One command, for Claude Code
 


### PR DESCRIPTION
Follow-up to [#13](https://github.com/samson-art/transcriptor-mcp/pull/13). Both badges encode the endpoint as base64 inside the `config` query parameter, so the plain-text and percent-encoded rewrites in 1.2.3 walked past them and the two one-click badges still installed `https://gateway.mcpal.io/mcp/transcriptor`.

All three README install links now match what `installLinks` in [web/clients.mjs](web/clients.mjs) generates (verified by importing the module and asserting each URL appears in the README verbatim).

No version bump: nothing published from the repo changes. `server.json` is untouched, and the landing page's install buttons were always generated from `SERVER_URL`, so they were correct already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)