### PR TITLE
Declare destructiveHint on all eight MCP tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ mcp-analytics-gateway/
 store/
 assets/store/
 .claude/
+chatgpt-app-submission.json

--- a/src/mcp-core.ts
+++ b/src/mcp-core.ts
@@ -388,7 +388,12 @@ export function createMcpServer(opts?: CreateMcpServerOptions) {
         'Fetch cleaned subtitles as plain text for a video (YouTube, Twitter/X, Instagram, TikTok, Twitch, Vimeo, Facebook, Bilibili, VK, Dailymotion, Reddit). Uses auto-discovery for type/language when omitted. Optional: type, lang, response_limit (when omitted returns full transcript), next_cursor for pagination.',
       inputSchema: subtitleInputSchema.shape,
       outputSchema: transcriptOutputSchema.shape,
-      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+        destructiveHint: false,
+      },
       _meta: {
         ui: { resourceUri: TRANSCRIPT_UI_URI },
         'openai/outputTemplate': TRANSCRIPT_UI_URI,
@@ -449,7 +454,12 @@ export function createMcpServer(opts?: CreateMcpServerOptions) {
         'Fetch raw SRT/VTT subtitles for a video (supported platforms). Optional: type, lang, response_limit (when omitted returns full content), next_cursor for pagination.',
       inputSchema: subtitleInputSchema,
       outputSchema: rawSubtitlesOutputSchema,
-      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+        destructiveHint: false,
+      },
     },
     async (args, _extra) =>
       withToolErrorHandling(TOOL_GET_RAW_SUBTITLES, log, async () => {
@@ -500,7 +510,12 @@ export function createMcpServer(opts?: CreateMcpServerOptions) {
       description: 'List available official and auto-generated subtitle languages.',
       inputSchema: baseInputSchema,
       outputSchema: availableSubtitlesOutputSchema,
-      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+        destructiveHint: false,
+      },
     },
     async (args, _extra) =>
       withToolErrorHandling(
@@ -545,7 +560,12 @@ export function createMcpServer(opts?: CreateMcpServerOptions) {
         'Fetch extended metadata for a video (title, channel, duration, tags, thumbnails, etc.).',
       inputSchema: baseInputSchema.shape,
       outputSchema: videoInfoOutputSchema.shape,
-      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+        destructiveHint: false,
+      },
       _meta: {
         ui: { resourceUri: VIDEO_INFO_UI_URI },
         'openai/outputTemplate': VIDEO_INFO_UI_URI,
@@ -621,7 +641,12 @@ export function createMcpServer(opts?: CreateMcpServerOptions) {
       description: 'Fetch chapter markers (start/end time, title) for a video.',
       inputSchema: baseInputSchema,
       outputSchema: videoChaptersOutputSchema,
-      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+        destructiveHint: false,
+      },
     },
     async (args, _extra) =>
       withToolErrorHandling(
@@ -669,7 +694,12 @@ export function createMcpServer(opts?: CreateMcpServerOptions) {
         'Capture a single frame from a video at the given timestamp. Provide timecode ("01:23", "00:01:23.500") or seconds; defaults to the first frame. Optional: format (png|jpeg), width (max 1920), quality (jpeg, 2-31). Returns the image plus metadata.',
       inputSchema: videoFrameInputSchema.shape,
       outputSchema: videoFrameOutputSchema.shape,
-      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+        destructiveHint: false,
+      },
       _meta: {
         ui: { resourceUri: VIDEO_FRAME_UI_URI },
         'openai/outputTemplate': VIDEO_FRAME_UI_URI,
@@ -727,7 +757,12 @@ export function createMcpServer(opts?: CreateMcpServerOptions) {
         'Fetch cleaned subtitles (plain text) for multiple videos from a playlist. Use playlistItems (e.g. "1:5") to select specific items, maxItems to limit count.',
       inputSchema: playlistTranscriptsInputSchema,
       outputSchema: playlistTranscriptsOutputSchema,
-      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+        destructiveHint: false,
+      },
     },
     async (args, _extra) =>
       withToolErrorHandling(TOOL_GET_PLAYLIST_TRANSCRIPTS, log, async () => {
@@ -794,7 +829,12 @@ export function createMcpServer(opts?: CreateMcpServerOptions) {
         'Search videos on YouTube via yt-dlp (ytsearch). Returns list of matching videos with metadata. Optional: limit, offset (pagination), uploadDateFilter (hour|today|week|month|year), dateBefore, date, matchFilter (e.g. "!is_live"), response_format (json|markdown).',
       inputSchema: searchInputSchema.shape,
       outputSchema: searchVideosOutputSchema.shape,
-      annotations: { readOnlyHint: true, idempotentHint: false, openWorldHint: true },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+        destructiveHint: false,
+      },
       _meta: {
         ui: { resourceUri: SEARCH_UI_URI },
         'openai/outputTemplate': SEARCH_UI_URI,


### PR DESCRIPTION
## What

Adds an explicit `destructiveHint: false` to the `annotations` of all eight MCP tools in `src/mcp-core.ts`, and ignores the generated `chatgpt-app-submission.json`.

## Why

ChatGPT Apps submission review requires `readOnlyHint`, `openWorldHint` and `destructiveHint` to be set explicitly on every tool. A missing hint is a submission blocker, even though MCP clients apply protocol-level defaults — the reviewer reads what the server advertises, not what the spec defaults to. Before this change none of the eight tools declared `destructiveHint`.

`false` is correct for every tool: `get_transcript`, `get_raw_subtitles`, `get_available_subtitles`, `get_video_info`, `get_video_chapters`, `get_video_frame`, `get_playlist_transcripts` and `search_videos` only fetch public captions, metadata, chapters, frames and search results. Nothing is deleted, overwritten or otherwise made irreversible; `get_video_frame`'s temporary working file is cleaned up by the existing capture path.

## Notes for the reviewer

- **`openWorldHint` stays `true`.** The Codex submission skill defines the flag as "can change publicly visible internet state", under which these tools would be `false`. That contradicts the MCP spec, where `true` means the tool reaches an open world of external entities — which these do, via yt-dlp against third-party platforms. Keeping `true` stays spec-correct for every other MCP client and is the conservative answer for review; the read-only nature is spelled out in the submission JSON's justifications instead.
- **Formatting.** Prettier expanded the one-line `annotations` objects into multi-line blocks, which is why the diff is larger than eight added lines. No other behaviour changed.
- **Deploy before submitting.** The hosted gateway at `transcriptor.gateway.mcpal.io` serves the previous build, so review would still see tools without `destructiveHint` until this ships.
- **`.gitignore`.** `chatgpt-app-submission.json` is generated per submission and now ignored, matching how `store/` and `assets/store/` collateral is already kept out of git.
- Pre-commit ran the full pipeline: lint, format check, type-check, 246 tests, build — all green.