### PR TITLE
Release 1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.4] - 2026-08-29
+
+### Fixed
+
+- **All eight tools now declare `destructiveHint`:** the annotations set `readOnlyHint`, `idempotentHint` and `openWorldHint` but left `destructiveHint` unset, so clients had to fall back to the protocol default. ChatGPT Apps review reads what the server advertises rather than what the spec defaults to, and treats a missing hint as a submission blocker. `false` is correct for every tool — `get_transcript`, `get_raw_subtitles`, `get_available_subtitles`, `get_video_info`, `get_video_chapters`, `get_video_frame`, `get_playlist_transcripts` and `search_videos` only retrieve public captions, metadata, chapters, frames and search results. `openWorldHint` stays `true`: the tools do reach third-party platforms over the public internet, which is what the flag means in the MCP spec.
+- **Cursor and LM Studio install badges pointed at the old endpoint** in the README connect section, so a one-click install produced a configuration holding the retired path-based URL.
+
 ## [1.2.3] - 2026-08-28
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transcriptor-mcp",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transcriptor-mcp",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transcriptor-mcp",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Fetch transcripts, subtitles, chapters, metadata and frames from YouTube and 10+ video platforms",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.samson-art/transcriptor-mcp",
   "title": "Transcriptor MCP",
   "description": "Fetch transcripts, subtitles, chapters, metadata and frames from YouTube and 10+ video platforms",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "websiteUrl": "https://github.com/samson-art/transcriptor-mcp#readme",
   "repository": {
     "url": "https://github.com/samson-art/transcriptor-mcp",
@@ -27,7 +27,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "docker.io/artsamsonov/transcriptor-mcp:1.2.3",
+      "identifier": "docker.io/artsamsonov/transcriptor-mcp:1.2.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## What

Version bump to 1.2.4: `package.json`, `package-lock.json`, `server.json` (both the `version` field and the OCI package tag), and a new `CHANGELOG.md` section.

## What ships in 1.2.4

- **`destructiveHint` declared on all eight tools** (#15). The annotations previously set `readOnlyHint`, `idempotentHint` and `openWorldHint` but left `destructiveHint` unset. ChatGPT Apps review treats a missing hint as a submission blocker, so this unblocks the plugin submission.
- **Cursor and LM Studio install badges repointed** (#14). Both carried a base64 config holding the retired `gateway.mcpal.io/mcp/transcriptor` URL, so a one-click install produced a broken configuration.

## Why server.json is synced here

The `publish-registry` job rewrites `server.json` to the released version at publish time, so this commit is not what the registry reads. It is committed anyway to match the previous releases and to keep the repo from drifting a version behind the published entry.

## After merge

Pushing the `v1.2.4` tag triggers `publish-docker.yml`: multi-arch API and MCP images to Docker Hub (`:1.2.4` and `:latest`), then the MCP Registry entry via `mcp-publisher login github-oidc`.

Separately, the hosted gateway at `transcriptor.gateway.mcpal.io` has to pull the new image before ChatGPT Apps review sees the corrected annotations.