### PR TITLE
Add a support page at /support

### DIFF
--- a/web/build.mjs
+++ b/web/build.mjs
@@ -23,6 +23,7 @@ const legalPages = [
   { source: 'legal/TERMS_OF_SERVICE.md', dir: 'terms' },
   { source: 'legal/PRIVACY_POLICY.md', dir: 'privacy' },
   { source: 'legal/EULA.md', dir: 'eula' },
+  { source: 'web/support.md', dir: 'support' },
 ];
 
 // Cross-document links inside legal/*.md point at sibling markdown files;
@@ -230,7 +231,7 @@ function renderJsonLd() {
 }
 
 function renderSitemap() {
-  const paths = ['/', '/terms/', '/privacy/', '/eula/'];
+  const paths = ['/', '/support/', '/terms/', '/privacy/', '/eula/'];
   const urls = paths
     .map(
       (p) =>

--- a/web/index.html
+++ b/web/index.html
@@ -525,6 +525,7 @@
       <a href="https://hub.docker.com/r/artsamsonov/transcriptor-mcp">Docker Hub</a>
       <a href="https://registry.modelcontextprotocol.io/v0/servers?search=transcriptor">MCP Registry</a>
       <a href="/llms.txt">llms.txt</a>
+      <a href="/support/">Support</a>
       <a href="/terms/">Terms of Service</a>
       <a href="/privacy/">Privacy Policy</a>
       <a href="mailto:contact@transcriptor-mcp.org">Contact</a>

--- a/web/support.md
+++ b/web/support.md
@@ -1,0 +1,40 @@
+# Support
+
+Transcriptor is an MCP server that gives AI assistants transcripts, chapters,
+metadata and frames from 11 video platforms. If something does not work, or
+you are not sure how to connect it — this page is the way in.
+
+## Report a problem
+
+Open an issue on GitHub — it is the fastest route and the whole history is
+public:
+
+**[github.com/samson-art/transcriptor-mcp/issues](https://github.com/samson-art/transcriptor-mcp/issues)**
+
+A useful report names the client (Claude, ChatGPT, Cursor, …), the tool that
+failed (for example `get_transcript`), the video URL you asked about, and the
+error text as the assistant showed it. The server never needs your password or
+tokens for any video platform, so a report never has to include secrets.
+
+## Ask by email
+
+If GitHub is not your thing: [contact@transcriptor-mcp.org](mailto:contact@transcriptor-mcp.org).
+
+## Connect and usage help
+
+- [How to connect](/#connect) — a ready snippet for each supported client.
+- [What you can ask](/#ask) — the eight tools with example prompts.
+- [README](https://github.com/samson-art/transcriptor-mcp#readme) — full
+  documentation, self-hosting included.
+
+## Account and sign-in
+
+Sign-in happens in the browser through OAuth on the first connection; there
+are no API keys to manage. To revoke access, disconnect the server in your
+client — the session dies with it.
+
+## Legal and rights holders
+
+Takedown requests and legal matters go to
+[legal@transcriptor-mcp.org](mailto:legal@transcriptor-mcp.org) — see the
+[Terms of Service](/terms/) and the [Privacy Policy](/privacy/).

--- a/web/template.html
+++ b/web/template.html
@@ -133,6 +133,7 @@
   </main>
   <footer class="site">
     <a href="/">Home</a>
+    <a href="/support/">Support</a>
     <a href="/terms/">Terms of Service</a>
     <a href="/privacy/">Privacy Policy</a>
     <a href="mailto:legal@transcriptor-mcp.org">legal@transcriptor-mcp.org</a>


### PR DESCRIPTION
The ChatGPT plugin submission form requires an HTTPS **Customer support URL**; the site had only a `mailto:` in the footer.

`/support` now renders from [web/support.md](https://github.com/samson-art/transcriptor-mcp/blob/site/support-page/web/support.md) through the same pipeline as the legal pages: GitHub issues for problems (with a note that reports never need secrets), `contact@` for email, landing anchors for connect help, `legal@` + ToS/Privacy for rights holders. Linked from both footers, added to the sitemap.

Verified in the built output: title, canonical `/support/`, sitemap entry, external links open in a new tab, landing anchors it points at exist.

Once merged, the deploy workflow publishes it; the portal form then takes `https://transcriptor-mcp.org/support`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)